### PR TITLE
Reframe website from consulting focus to AI product/startup positioning

### DIFF
--- a/content/sections/about-us.md
+++ b/content/sections/about-us.md
@@ -4,8 +4,8 @@ id: "about-us"
 subtitle: "Pioneering AI Solutions from the Heart of Vienna"
 ---
 
-synapsy<span class="brand-highlight">x</span> is an independent research, development, and distribution company headquartered in Vienna, Austria. We are passionate about the transformative potential of software applications, particularly in the realm of Artificial Intelligence. Our mission is to explore, innovate, and deliver intelligent solutions that redefine possibilities.
+synapsy<span class=”brand-highlight”>x</span> is an AI-first startup headquartered in Vienna, Austria. We build intelligent tools and platforms that solve real problems — from AI-powered education tools deployed internationally to proprietary automation pipelines that streamline complex workflows like grant proposal writing.
 
-While deeply rooted in the vibrant tech scene of Vienna, our perspective is inherently international. We cultivate global connections and draw upon diverse experiences to enrich our work. We aren’t just developers; we are thinkers, researchers, and problem-solvers who thrive on tackling complex challenges.
+Our perspective is inherently international. With a strong base in the DACH region and collaborations spanning multiple continents, we bring global context to every solution we build. Our team has spent years working intensively with AI, developing deep expertise in effective AI deployment, prompt engineering, and building proprietary tooling.
 
-Our commitment lies in finding those unique, “wildcard” solutions that others might overlook, ensuring we always operate at the bleeding edge of technological progress. We believe in the power of focused expertise and agile development to create truly impactful software and digital experiences.
+We find the “wildcard” solutions others overlook. We believe in shipping working products, learning fast, and staying at the frontier of what AI can do.

--- a/content/sections/hero-section.md
+++ b/content/sections/hero-section.md
@@ -1,5 +1,5 @@
 ---
-title: "Driving Innovation through Technology and Digital Excellence"
+title: "Building AI-Powered Tools for Real-World Impact"
 ---
 
-We advance AI research, build custom applications, and provide strategic tech consulting. From early discovery to production deployment, we align models, data, and workflows to deliver measurable business impact.
+We design and deploy AI solutions — from intelligent platforms and automation pipelines to AI-powered tools for education and institutional workflows. From prototype to production, we turn AI capabilities into measurable outcomes.

--- a/content/sections/services/_index.md
+++ b/content/sections/services/_index.md
@@ -1,4 +1,4 @@
 ---
-title: "Our services"
+title: "What we build"
 ---
-We combine cutting-edge AI research, practical application development, and hands-on consulting to help organizations unlock real business value from artificial intelligence.
+We design, build, and deploy AI-powered solutions — from intelligent platforms and automation pipelines to custom tools that help organizations unlock real value from artificial intelligence.

--- a/content/sections/services/ai-research-development.md
+++ b/content/sections/services/ai-research-development.md
@@ -4,10 +4,10 @@ image: "images/services/ai-research.png"
 alt: "AI Research & Development"
 weight: 1
 features:
-  - "Custom AI optimisation"
-  - "Machine learning model fine-tuning"
-  - "Automatisation design"
-  - "Prototype testing and validation"
+  - "Prompt engineering & context design"
+  - "AI pipeline architecture"
+  - "Automation design"
+  - "Prototype to production deployment"
 ---
 
-We're at the forefront of artificial intelligence innovation, creating custom algorithms and models that solve complex problems. Our research team explores emerging AI technologies, including machine learning, neural networks, and natural language processing, to develop solutions that give our clients a competitive edge.
+We explore, test, and systematise what works with AI — building proprietary tooling, reusable templates, and multi-stage pipelines that turn AI capabilities into reliable, production-ready solutions. Our R&D feeds directly into the products we build and deploy.

--- a/content/sections/services/ai-software-applications.md
+++ b/content/sections/services/ai-software-applications.md
@@ -1,13 +1,13 @@
 ---
-title: "AI Software Applications"
+title: "AI-Powered Platforms & Tools"
 image: "images/services/ai-software.png"
-alt: "AI Software Applications"
+alt: "AI-Powered Platforms & Tools"
 weight: 2
 features:
-  - "AI-powered business applications"
-  - "Predictive analytics platforms"
-  - "Recommendation systems"
-  - "Compliance by design"
+  - "Custom AI-powered platforms"
+  - "LMS & LTI integrations"
+  - "Intelligent automation pipelines"
+  - "End-to-end solution deployment"
 ---
 
-We transform AI concepts into practical, scalable software solutions tailored to your specific business needs. Our development team creates intelligent applications that automate processes, analyze data, and provide actionable insights, helping your organization operate more efficiently.
+We build and deploy AI-powered tools and platforms tailored to specific domains — from intelligent education tools with LMS integration to automated workflow pipelines that handle complex, multi-step processes. We take solutions from concept to production and into the hands of real users.

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -1,13 +1,13 @@
 ---
-title: "Strategic Technology Consulting"
+title: "AI Strategy & Implementation"
 image: "images/services/digitization.png"
-alt: "Strategic Technology Consulting"
+alt: "AI Strategy & Implementation"
 weight: 5
 features:
-  - "Creating custom AI strategies"
-  - "Future-proof workflows"
-  - "Process mining & optimisation"
-  - "Big picture AI integrations"
+  - "AI readiness assessment"
+  - "Workflow automation design"
+  - "Tool selection & integration"
+  - "Workshops & training"
 ---
 
-We help our customers bringing their organisations into the age of AI by analysing processes, finding potential and helping to find technology strategies for the whole business instead of just isolated applications.
+We help organisations adopt AI effectively — identifying high-impact opportunities, designing AI-powered workflows, and delivering hands-on workshops and training. We work especially closely with universities and institutions navigating the AI transition.

--- a/content/sections/team/_index.md
+++ b/content/sections/team/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Our Team
-subTitle: Passionate Innovators & AI Specialists
+subTitle: Builders, Operators & AI Specialists
 ---
 
-The strength of synapsyx lies in our dedicated team. We are a close-knit group of highly skilled AI specialists, brought together by a shared passion for innovation and technology. Our backgrounds are intentionally diverse and interdisciplinary, blending expertise from computer science, mathematics, engineering, design, and more. This rich mix of perspectives allows us to approach problems creatively and develop truly holistic solutions. Each member brings international experience and a commitment to continuous learning, ensuring we remain leaders in the fast-evolving world of AI and software development.
+The strength of synapsyx lies in our dedicated team. We are a close-knit group brought together by a shared conviction that AI is the most important technology of our era. Our backgrounds are intentionally diverse and interdisciplinary, spanning computer science, engineering, economics, and law. This mix of perspectives allows us to approach problems creatively and build holistic solutions. Every team member brings international experience and a commitment to continuous learning, ensuring we stay at the frontier of AI development.

--- a/themes/synapsyx/layouts/_partials/footer.html
+++ b/themes/synapsyx/layouts/_partials/footer.html
@@ -17,8 +17,7 @@
                     </a>
                 </div>
                 <p class="footer-about">
-                    Independent AI research and development, creating intelligent solutions that push technological
-                    boundaries.
+                    AI-first startup building intelligent tools and platforms — from AI-powered education solutions to automated workflow pipelines.
                 </p>
                 <div class="social-links mt-3">
                     <a href="https://linkedin.com/company/synapsyx" target="_blank" aria-label="LinkedIn">


### PR DESCRIPTION
- Hero: lead with building AI tools, remove consulting mention
- About: position as AI-first startup, mention real deployments and expertise
- Services: rename section to "What we build", update all three cards to reflect actual capabilities (prompt engineering, AI pipelines, LTI integrations, workshops) instead of generic ML buzzwords
- Rename "Strategic Technology Consulting" to "AI Strategy & Implementation"
- Team: fix disciplines to match actual backgrounds, update subtitle
- Footer: update tagline to reflect product company positioning