### PR TITLE
Tone down specificity: restore original headline, generalize domain refs

### DIFF
--- a/content/sections/about-us.md
+++ b/content/sections/about-us.md
@@ -4,7 +4,7 @@ id: "about-us"
 subtitle: "Pioneering AI Solutions from the Heart of Vienna"
 ---
 
-synapsy<span class=”brand-highlight”>x</span> is an AI-first startup headquartered in Vienna, Austria. We build intelligent tools and platforms that solve real problems — from AI-powered education tools deployed internationally to proprietary automation pipelines that streamline complex workflows like grant proposal writing.
+synapsy<span class=”brand-highlight”>x</span> is an AI-first startup headquartered in Vienna, Austria. We build intelligent tools and platforms that solve real problems — from AI-powered applications deployed internationally to proprietary automation pipelines that streamline complex, multi-step workflows.
 
 Our perspective is inherently international. With a strong base in the DACH region and collaborations spanning multiple continents, we bring global context to every solution we build. Our team has spent years working intensively with AI, developing deep expertise in effective AI deployment, prompt engineering, and building proprietary tooling.
 

--- a/content/sections/hero-section.md
+++ b/content/sections/hero-section.md
@@ -1,5 +1,5 @@
 ---
-title: "Building AI-Powered Tools for Real-World Impact"
+title: "Driving Innovation through Technology and Digital Excellence"
 ---
 
-We design and deploy AI solutions — from intelligent platforms and automation pipelines to AI-powered tools for education and institutional workflows. From prototype to production, we turn AI capabilities into measurable outcomes.
+We design and deploy AI solutions — from intelligent platforms and automation pipelines to custom tools that solve complex, domain-specific problems. From prototype to production, we turn AI capabilities into measurable outcomes.

--- a/content/sections/services/ai-software-applications.md
+++ b/content/sections/services/ai-software-applications.md
@@ -5,9 +5,9 @@ alt: "AI-Powered Platforms & Tools"
 weight: 2
 features:
   - "Custom AI-powered platforms"
-  - "LMS & LTI integrations"
+  - "Third-party system integrations"
   - "Intelligent automation pipelines"
   - "End-to-end solution deployment"
 ---
 
-We build and deploy AI-powered tools and platforms tailored to specific domains — from intelligent education tools with LMS integration to automated workflow pipelines that handle complex, multi-step processes. We take solutions from concept to production and into the hands of real users.
+We build and deploy AI-powered tools and platforms tailored to specific domains — integrating seamlessly into existing systems and automating complex, multi-step processes. We take solutions from concept to production and into the hands of real users.

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -10,4 +10,4 @@ features:
   - "Workshops & training"
 ---
 
-We help organisations adopt AI effectively — identifying high-impact opportunities, designing AI-powered workflows, and delivering hands-on workshops and training. We work especially closely with universities and institutions navigating the AI transition.
+We help organisations adopt AI effectively — identifying high-impact opportunities, designing AI-powered workflows, and delivering hands-on workshops and training. We work with companies, universities, and public institutions alike.


### PR DESCRIPTION
- Restore original hero title (less clumsy)
- Remove education/institutional workflows from hero body
- Replace "grant proposal writing" with general "multi-step workflows"
- Replace "LMS & LTI integrations" with "Third-party system integrations"
- Soften university focus in strategy card to broader client list

https://claude.ai/code/session_01GgmtJcBwBfC2oN4fxZaVTg