### PR TITLE
Remove all consulting language from website

### DIFF
--- a/content/imprint.md
+++ b/content/imprint.md
@@ -47,5 +47,5 @@ All contents and works published on this website are subject to Austrian copyrig
 
 ## Basic orientation of the website
 
-This website presents synapsyx GmbH and its consulting services in the field of artificial intelligence.
+This website presents synapsyx GmbH and its AI solutions and services.
 (No periodic editorial content is published; §§ 24-25 MedienG therefore do not apply.)

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Strategy & Implementation"
+title: "AI Enablement & Training"
 image: "images/services/digitization.png"
-alt: "AI Strategy & Implementation"
+alt: "AI Enablement & Training"
 weight: 5
 features:
   - "AI readiness assessment"

--- a/content/sections/team/strudl.md
+++ b/content/sections/team/strudl.md
@@ -2,6 +2,6 @@
 name: "Michael Strobl, BSc."
 image: "/images/team/michael_nobg.png"
 position: "Managing Director"
-bioSummary: "Michael drives digital-transformation and AI projects. Drawing on a degree in Economics and Big 4 forensic-tech experience, Michael combines consulting know-how with rigorous analytics."
+bioSummary: "Michael drives digital-transformation and AI projects. Drawing on a degree in Economics and Big 4 forensic-tech experience, Michael combines analytical rigour with hands-on product development."
 linkedin: "https://www.linkedin.com/in/michael-strobl-429a57211"
 ---

--- a/content/terms-of-use.md
+++ b/content/terms-of-use.md
@@ -6,12 +6,12 @@ draft: false
 
 # GENERAL TERMS & CONDITIONS
 
-of synapsyx GmbH for Consulting, Development and Delivery of AI-Based Software Solutions
+of synapsyx GmbH for Development and Delivery of AI-Based Software Solutions
 (version 1 / in force from 07 July 2025)
 
 ## 1. Scope and hierarchy
 
-1.1 These GTC govern every present and future contract under which synapsyx GmbH (“Provider”) supplies consulting services, software or AI-generated outputs to an entrepreneur within the meaning of § 1 UGB (“Client”). The Provider rejects any conflicting, deviating or supplemental terms of the Client unless the Provider expressly accepts them in writing.
+1.1 These GTC govern every present and future contract under which synapsyx GmbH (“Provider”) supplies services, software or AI-generated outputs to an entrepreneur within the meaning of § 1 UGB (“Client”). The Provider rejects any conflicting, deviating or supplemental terms of the Client unless the Provider expressly accepts them in writing.
 
 1.2  Individual written agreements (including statements of work, SLAs or licence terms) take precedence over these GTC in case of conflict.
 
@@ -19,7 +19,7 @@ of synapsyx GmbH for Consulting, Development and Delivery of AI-Based Software S
 
 2.1  The exact scope, milestones and fees result from the Provider’s offer or the parties’ statement of work (“SOW”).
 
-2.2  The Client shall supply in due time all information, test data, access rights and qualified personnel that are reasonably necessary for the orderly performance of the services. Delays or additional efforts caused by the Client’s failure to cooperate may be invoiced at the Provider’s then-current consulting rates.
+2.2  The Client shall supply in due time all information, test data, access rights and qualified personnel that are reasonably necessary for the orderly performance of the services. Delays or additional efforts caused by the Client’s failure to cooperate may be invoiced at the Provider’s then-current rates.
 
 2.3  Unless otherwise agreed, services are performed remotely during Austrian business hours.
 


### PR DESCRIPTION
- Rename "AI Strategy & Implementation" to "AI Enablement & Training"
- Update Michael's bio: replace "consulting know-how" with "analytical rigour with hands-on product development"
- GTC: remove "Consulting" from title and "consulting services/rates" from body text
- Imprint: replace "consulting services" with "AI solutions and services"
- Note: WKO division name "Unternehmensberatung" kept as-is (legal fact)

https://claude.ai/code/session_01GgmtJcBwBfC2oN4fxZaVTg