### PR TITLE
Rewrite AI Enablement section and remove workshops focus

### DIFF
--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -7,7 +7,7 @@ features:
   - "AI readiness assessment"
   - "Workflow automation design"
   - "Tool selection & integration"
-  - "Workshops & training"
+  - "Custom AI tooling"
 ---
 
-We build AI-powered workflows and tools for organisations ready to adopt AI — and run hands-on workshops and training to make sure teams can use them effectively. We work with companies, universities, and public institutions alike.
+We design and build AI-powered workflows and internal tools that help organisations work faster and smarter — from automating repetitive processes to integrating AI into existing systems. We work with companies, universities, and public institutions alike.

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -10,4 +10,4 @@ features:
   - "Workshops & training"
 ---
 
-We help organisations adopt AI effectively — identifying high-impact opportunities, designing AI-powered workflows, and delivering hands-on workshops and training. We work with companies, universities, and public institutions alike.
+We build AI-powered workflows and tools for organisations ready to adopt AI — and run hands-on workshops and training to make sure teams can use them effectively. We work with companies, universities, and public institutions alike.


### PR DESCRIPTION
## Summary
- Rewrote AI Enablement & Training section body to lead with building workflows/tools instead of advisory language
- Removed workshops & training from features list, replaced with "Custom AI tooling"
- Body text now focuses on workflow automation and AI integration into existing systems

Follow-up to the first PR that reframed the site away from consulting.

https://claude.ai/code/session_01GgmtJcBwBfC2oN4fxZaVTg