### PR TITLE
Reframe services section from client offerings to company pillars

### DIFF
--- a/content/sections/services/_index.md
+++ b/content/sections/services/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "What we build"
 ---
-We design, build, and deploy AI-powered solutions — from intelligent platforms and automation pipelines to custom tools that help organizations unlock real value from artificial intelligence.
+We build AI-powered products and proprietary tooling. Everything we develop — from internal R&D infrastructure to deployed platforms — is designed to compound: each tool we build makes the next one faster and better.

--- a/content/sections/services/ai-research-development.md
+++ b/content/sections/services/ai-research-development.md
@@ -6,8 +6,8 @@ weight: 1
 features:
   - "Prompt engineering & context design"
   - "AI pipeline architecture"
-  - "Automation design"
-  - "Prototype to production deployment"
+  - "Proprietary template & tooling library"
+  - "Continuous evaluation of new AI capabilities"
 ---
 
-We explore, test, and systematise what works with AI — building proprietary tooling, reusable templates, and multi-stage pipelines that turn AI capabilities into reliable, production-ready solutions. Our R&D feeds directly into the products we build and deploy.
+Our R&D is the engine behind everything we ship. We build and maintain a growing library of proprietary tooling — reusable templates, multi-stage pipelines, and systematic approaches to prompt engineering — that accelerates all of our downstream products and deployments.

--- a/content/sections/services/ai-software-applications.md
+++ b/content/sections/services/ai-software-applications.md
@@ -1,13 +1,13 @@
 ---
-title: "AI-Powered Platforms & Tools"
+title: "AI-Powered Products"
 image: "images/services/ai-software.png"
-alt: "AI-Powered Platforms & Tools"
+alt: "AI-Powered Products"
 weight: 2
 features:
-  - "Custom AI-powered platforms"
-  - "Third-party system integrations"
   - "Intelligent automation pipelines"
-  - "End-to-end solution deployment"
+  - "AI-powered platforms & applications"
+  - "Third-party system integrations"
+  - "From prototype to production"
 ---
 
-We build and deploy AI-powered tools and platforms tailored to specific domains — integrating seamlessly into existing systems and automating complex, multi-step processes. We take solutions from concept to production and into the hands of real users.
+We turn our R&D into real products — AI-powered platforms and automation pipelines that are deployed, integrated into existing systems, and used by real people. Our products solve specific, high-impact problems in domains like education, institutional workflows, and beyond.

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -1,13 +1,13 @@
 ---
-title: "AI Enablement & Training"
+title: "Domain Expertise"
 image: "images/services/digitization.png"
-alt: "AI Enablement & Training"
+alt: "Domain Expertise"
 weight: 5
 features:
-  - "AI readiness assessment"
-  - "Workflow automation design"
-  - "Tool selection & integration"
-  - "Custom AI tooling"
+  - "Education & institutional intelligence"
+  - "Automated proposal & document workflows"
+  - "International project development"
+  - "AI-powered process design"
 ---
 
-We design and build AI-powered workflows and internal tools that help organisations work faster and smarter — from automating repetitive processes to integrating AI into existing systems. We work with companies, universities, and public institutions alike.
+We apply our technology where we know the domain deeply. Our current focus areas include education, international project development, and complex document workflows — sectors where AI can create outsized impact and where we have real deployment experience.


### PR DESCRIPTION
- Section intro: emphasize own products and compounding R&D
- AI R&D: position as the internal engine, not a service for hire
- AI Platforms & Tools → AI-Powered Products: frame as own products deployed to real users, not custom dev for clients
- AI Enablement → Domain Expertise: reframe as where we deploy our tech (education, project dev, document workflows) rather than what we do for clients

https://claude.ai/code/session_01GgmtJcBwBfC2oN4fxZaVTg