### PR TITLE
Fix smart quotes causing visible quotation marks on site

### DIFF
--- a/content/imprint.md
+++ b/content/imprint.md
@@ -29,7 +29,7 @@ Email: contact@synapsyx.com
 
 ## Legal Information
 
-Member of the Austrian Federal Economic Chamber (Wirtschaftskammer Österreich, WKO), Division “Unternehmensberatung, Buchhaltung & Informationstechnologie”
+Member of the Austrian Federal Economic Chamber (Wirtschaftskammer Österreich, WKO), Division "Unternehmensberatung, Buchhaltung & Informationstechnologie"
 
 Austrian Trade Regulation Act 1994 (GewO) – consolidated text available at the Federal Legal Information System (RIS): https://www.ris.bka.gv.at
 

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -20,7 +20,7 @@ E-mail: **contact@synapsyx.com**
 | Data category | Source | Purpose & legal basis | Retention |
 |--------------|--------|-----------------------|-----------|
 | **Server log data** (IP address, date/time, requested file, referrer, user-agent) | Automatically recorded by our hosting provider **GitHub Inc./B.V.** | • Deliver the pages<br>• Ensure security<br>**Legal basis:** legitimate interest (Art. 6 (1)(f) GDPR) | Deleted or anonymised after ≈ 30 days (GitHub standard) |
-| **Essential cookies** set by GitHub and its CDN (**Fastly**) – e.g. `_gh_sess`, `_octo`, `color_mode` | Browser | Technical operation, load balancing, rate-limiting<br>**Legal basis:** legitimate interest (Art. 6 (1)(f) GDPR) | Session-only or as stated in the cookie’s expiration attribute |
+| **Essential cookies** set by GitHub and its CDN (**Fastly**) – e.g. `_gh_sess`, `_octo`, `color_mode` | Browser | Technical operation, load balancing, rate-limiting<br>**Legal basis:** legitimate interest (Art. 6 (1)(f) GDPR) | Session-only or as stated in the cookie's expiration attribute |
 
 > We **do not** place any analytics, tracking or marketing cookies, and the site offers **no forms, log-in, newsletter or user-upload** features.
 
@@ -28,7 +28,7 @@ E-mail: **contact@synapsyx.com**
 
 ## 3  Recipients and international transfers  
 The site is hosted on **GitHub Pages**, which uses **Fastly** as a global content-delivery network.  
-GitHub stores and processes data in the EU and the United States. Transfers to the US are protected by GitHub’s certification under the **EU–US Data Privacy Framework (DPF)** and the **Standard Contractual Clauses** contained in GitHub’s Data-Processing Agreement.
+GitHub stores and processes data in the EU and the United States. Transfers to the US are protected by GitHub's certification under the **EU–US Data Privacy Framework (DPF)** and the **Standard Contractual Clauses** contained in GitHub's Data-Processing Agreement.
 
 No other third parties receive your data from this website.
 
@@ -42,7 +42,7 @@ If you believe your data are processed unlawfully, you can lodge a complaint wit
 ---
 
 ## 5  Security  
-The site is delivered exclusively over HTTPS (TLS 1.3). Administrative access is protected by strong authentication, and the underlying infrastructure is maintained by GitHub’s security team, including regular patching, fire-walling and redundancy.
+The site is delivered exclusively over HTTPS (TLS 1.3). Administrative access is protected by strong authentication, and the underlying infrastructure is maintained by GitHub's security team, including regular patching, fire-walling and redundancy.
 
 ---
 
@@ -52,4 +52,4 @@ We do not use your data for profiling or automated decisions that produce legal 
 ---
 
 ## 7  Updates to this notice  
-We may revise this notice if the site’s functionality changes (e.g. if we add analytics or a contact form). The current version is always available at this URL.
+We may revise this notice if the site's functionality changes (e.g. if we add analytics or a contact form). The current version is always available at this URL.

--- a/content/sections/about-us.md
+++ b/content/sections/about-us.md
@@ -1,11 +1,11 @@
 ---
-title: “About us”
-id: “about-us”
-subtitle: “AI-First Startup from Vienna, Austria”
+title: "About us"
+id: "about-us"
+subtitle: "AI-First Startup from Vienna, Austria"
 ---
 
-**synapsy<span class=”brand-highlight”>x</span> GmbH** is an AI-first startup founded in **February 2025** and headquartered in **Vienna, Austria**. We build AI-powered products and automation pipelines that are deployed internationally — from career guidance platforms integrated into university learning management systems to AI-driven proposal writing pipelines used across multi-country consortia.
+**synapsy<span class="brand-highlight">x</span> GmbH** is an AI-first startup founded in **February 2025** and headquartered in **Vienna, Austria**. We build AI-powered products and automation pipelines that are deployed internationally — from career guidance platforms integrated into university learning management systems to AI-driven proposal writing pipelines used across multi-country consortia.
 
-Our products are developed and deployed in collaboration with partners in the European education space, including <a href=”https://prime-academy.eu” target=”_blank”>priME Academy</a> (Germany) and <a href=”https://sumo-technologies.com” target=”_blank”>SUMO Technologies</a> (Austria), within EU-funded projects such as the Erasmus+ <a href=”https://greeneduseeds.com” target=”_blank”>Green Edu Seeds</a> initiative — reaching institutions across Vietnam, Thailand, Ghana, Cambodia, and beyond.
+Our products are developed and deployed in collaboration with partners in the European education space, including <a href="https://prime-academy.eu" target="_blank">priME Academy</a> (Germany) and <a href="https://sumo-technologies.com" target="_blank">SUMO Technologies</a> (Austria), within EU-funded projects such as the Erasmus+ <a href="https://greeneduseeds.com" target="_blank">Green Edu Seeds</a> initiative — reaching institutions across Vietnam, Thailand, Ghana, Cambodia, and beyond.
 
 Our team combines backgrounds in computer science, engineering, economics, and law — with over two years of intensive, hands-on AI expertise in prompt engineering, pipeline architecture, and deploying AI products to production. We ship working products, learn fast, and stay at the frontier of what AI can do.

--- a/content/sections/team/george.md
+++ b/content/sections/team/george.md
@@ -2,6 +2,6 @@
 name: "Georg Thurnwalder, LL.B."
 image: "/images/team/george_nobg.png"
 position: "Managing Director"
-bioSummary: "With a degree in international business law, seasoned in start‑up execution, & a focus on transformative tech, Georg looks over the horizon to define synapsyx’s strategic bets. He tracks shifts in generative AI, identifies strategic openings and coordinates multi‑stakeholder execution that converts potential into real impact."
+bioSummary: "With a degree in international business law, seasoned in start‑up execution, & a focus on transformative tech, Georg looks over the horizon to define synapsyx's strategic bets. He tracks shifts in generative AI, identifies strategic openings and coordinates multi‑stakeholder execution that converts potential into real impact."
 linkedin: "https://www.linkedin.com/in/georg-t-719562213/"
 ---

--- a/content/terms-of-use.md
+++ b/content/terms-of-use.md
@@ -11,15 +11,15 @@ of synapsyx GmbH for Development and Delivery of AI-Based Software Solutions
 
 ## 1. Scope and hierarchy
 
-1.1 These GTC govern every present and future contract under which synapsyx GmbH (“Provider”) supplies services, software or AI-generated outputs to an entrepreneur within the meaning of § 1 UGB (“Client”). The Provider rejects any conflicting, deviating or supplemental terms of the Client unless the Provider expressly accepts them in writing.
+1.1 These GTC govern every present and future contract under which synapsyx GmbH ("Provider") supplies services, software or AI-generated outputs to an entrepreneur within the meaning of § 1 UGB ("Client"). The Provider rejects any conflicting, deviating or supplemental terms of the Client unless the Provider expressly accepts them in writing.
 
 1.2  Individual written agreements (including statements of work, SLAs or licence terms) take precedence over these GTC in case of conflict.
 
 ## 2. Services, deliverables, cooperation duties
 
-2.1  The exact scope, milestones and fees result from the Provider’s offer or the parties’ statement of work (“SOW”).
+2.1  The exact scope, milestones and fees result from the Provider's offer or the parties' statement of work ("SOW").
 
-2.2  The Client shall supply in due time all information, test data, access rights and qualified personnel that are reasonably necessary for the orderly performance of the services. Delays or additional efforts caused by the Client’s failure to cooperate may be invoiced at the Provider’s then-current rates.
+2.2  The Client shall supply in due time all information, test data, access rights and qualified personnel that are reasonably necessary for the orderly performance of the services. Delays or additional efforts caused by the Client's failure to cooperate may be invoiced at the Provider's then-current rates.
 
 2.3  Unless otherwise agreed, services are performed remotely during Austrian business hours.
 
@@ -27,7 +27,7 @@ of synapsyx GmbH for Development and Delivery of AI-Based Software Solutions
 
 3.1  All prices are net of VAT and payable within 14 days of invoice.
 
-3.2  Travel costs, accommodation and daily allowances are reimbursed against receipts in accordance with the Austrian Income Tax Act’s tax-free limits.
+3.2  Travel costs, accommodation and daily allowances are reimbursed against receipts in accordance with the Austrian Income Tax Act's tax-free limits.
 
 3.3  In case of late payment the Provider may charge default interest of 9.2 percentage points above the ECB base rate (§ 456 UGB) and suspend services until full payment.
 
@@ -35,7 +35,7 @@ of synapsyx GmbH for Development and Delivery of AI-Based Software Solutions
 
 4.1  Unless the SOW grants broader rights, the Client receives a non-exclusive, non-transferable, perpetual licence to use project deliverables solely for its own internal business purposes.
 
-4.2  Any source code, pretrained models, frameworks or generic know-how developed or owned by the Provider before or independently of the project (“Background IP”) remain the Provider’s property. The Client obtains no rights to Background IP other than those necessary to use the project deliverables.
+4.2  Any source code, pretrained models, frameworks or generic know-how developed or owned by the Provider before or independently of the project ("Background IP") remain the Provider's property. The Client obtains no rights to Background IP other than those necessary to use the project deliverables.
 
 4.3  The Client shall not de-compile, reverse engineer or otherwise attempt to derive the source of any source code or AI models unless this is indispensable under § 40e UrhG and the Provider has been asked first. 
 
@@ -59,7 +59,7 @@ of synapsyx GmbH for Development and Delivery of AI-Based Software Solutions
 
 7.1  The Provider is liable without limitation for damages caused intentionally or by gross negligence, for personal injury, and under the Product Liability Act.
 
-7.2  In all other cases the Provider’s aggregate liability per contract is limited to 100 % of the fees paid under that contract; liability for lost profit, lost data, indirect or consequential damages is excluded to the extent permitted by law.  ￼
+7.2  In all other cases the Provider's aggregate liability per contract is limited to 100 % of the fees paid under that contract; liability for lost profit, lost data, indirect or consequential damages is excluded to the extent permitted by law.  ￼
 
 ## 8. Confidentiality
 
@@ -75,7 +75,7 @@ The Client warrants that it will not use the deliverables in violation of Austri
 
 ## 11. Term, termination
 
-11.1  Unless stated otherwise in the SOW, either party may terminate a continuing service contract for convenience with four (4) weeks’ written notice to the end of any calendar month.
+11.1  Unless stated otherwise in the SOW, either party may terminate a continuing service contract for convenience with four (4) weeks' written notice to the end of any calendar month.
 
 11.2  Either party may terminate for cause with immediate effect if the other party materially breaches the contract and fails to cure within 30 days of written notice.
 


### PR DESCRIPTION
## Summary
- Replaced Unicode curly/smart quotes (`"` `"`) with straight quotes (`"`) across all content files
- These were causing YAML frontmatter values (like "About us" and the subtitle) to render with visible quotation marks on the page

## Files fixed
- `content/sections/about-us.md`
- `content/sections/team/george.md`
- `content/imprint.md`
- `content/privacy-policy.md`
- `content/terms-of-use.md`

https://claude.ai/code/session_01GsyBEYxZ6G2a94tgQevMts