### PR TITLE
Revise website copy based on founder feedback

### DIFF
--- a/content/sections/about-us.md
+++ b/content/sections/about-us.md
@@ -4,7 +4,7 @@ id: "about-us"
 subtitle: "AI-First Startup from Vienna, Austria"
 ---
 
-**synapsy<span class="brand-highlight">x</span> GmbH** is an AI-first startup founded in **February 2025** and headquartered in **Vienna, Austria**. We build AI-powered products and automation pipelines that are deployed internationally — from career guidance platforms integrated into university learning management systems to AI-driven proposal writing pipelines used across multi-country consortia.
+**synapsy<span class="brand-highlight">x</span> GmbH** is an AI-first startup headquartered in **Vienna, Austria**. We build AI-powered products and automation pipelines deployed internationally — from career guidance platforms integrated into university learning management systems to AI-driven project development pipelines used across multi-country consortia.
 
 Our products are developed and deployed in collaboration with partners in the European education space, including <a href="https://prime-academy.eu" target="_blank">priME Academy</a> (Germany) and <a href="https://sumo-technologies.com" target="_blank">SUMO Technologies</a> (Austria), within EU-funded projects such as the Erasmus+ <a href="https://greeneduseeds.com" target="_blank">Green Edu Seeds</a> initiative — reaching institutions across Vietnam, Thailand, Ghana, Cambodia, and beyond.
 

--- a/content/sections/hero-section.md
+++ b/content/sections/hero-section.md
@@ -2,4 +2,4 @@
 title: "AI Solutions — From Concept to Production"
 ---
 
-We build and deploy AI-powered products for education, institutional workflows, and complex document automation. Our platforms are live, our pipelines are proven, and our tools are used by real people across multiple countries.
+We build and deploy AI-powered products for education, institutional workflows, and complex document automation — from intelligent platforms to semi-automated pipelines, across multiple countries.

--- a/content/sections/services/tech-consulting.md
+++ b/content/sections/services/tech-consulting.md
@@ -1,13 +1,13 @@
 ---
-title: "G/S-Flow — AI Proposal Automation Pipeline"
+title: "AI-Powered Project Development Pipeline"
 image: "images/services/digitization.png"
-alt: "G/S-Flow — AI Proposal Automation Pipeline"
+alt: "AI-Powered Project Development Pipeline"
 weight: 2
 features:
-  - "Multi-stage AI pipeline for drafting, analyzing, and refining grant & subsidy proposals"
-  - "Proprietary reference library with past proposals and official evaluations"
-  - "Successfully used for multiple Erasmus+ CBHE proposals across Africa & Southeast Asia"
-  - "Dramatically accelerates proposal writing while maintaining high quality"
+  - "Multi-stage AI pipeline: situation analysis, research, project development, and proposal drafting"
+  - "Semi-automated with human-in-the-loop at all critical decision points"
+  - "Used for international project development across EU programmes"
+  - "Achieves both quality and speed through structured AI-assisted workflows"
 ---
 
-**G/S-Flow** is our proprietary AI-powered automation pipeline for grant and subsidy proposal writing. It combines multi-stage prompt pipelines with a curated reference library of past proposals and their official evaluations to produce high-quality drafts at speed. G/S-Flow has already been used to complete multiple proposals for EU Erasmus+ programmes — with consistently positive feedback from consortium partners across several countries.
+Our project development pipeline is a semi-automated, multi-stage AI system that guides projects from initial analysis through research, development, and proposal drafting. Human experts stay in the loop at every critical point — ensuring quality while dramatically accelerating the process. The pipeline is actively used for international project development, particularly across EU-funded programmes in collaboration with partners in multiple countries.


### PR DESCRIPTION
## Summary
- Remove defensive "trust me we're real" language from hero section
- Drop "founded in February 2025" LinkedIn-style opener from About us
- Completely rework pipeline card: remove G/S-Flow name and reference library details, reframe as "AI-Powered Project Development Pipeline" with human-in-the-loop emphasis — more accurate and avoids sounding like a consulting service

https://claude.ai/code/session_01GsyBEYxZ6G2a94tgQevMts