### PR TITLE
Move ePATH showcase below Products, fix partner logos

### DIFF
--- a/content/sections/services/ai-software-applications.md
+++ b/content/sections/services/ai-software-applications.md
@@ -1,7 +1,7 @@
 ---
 title: "ePATH — AI Career Guidance Platform"
-image: "images/services/ePATH_counsellor.png"
-alt: "ePATH AI counselor interface"
+image: "images/services/ai-software.png"
+alt: "ePATH — AI Career Guidance Platform"
 weight: 1
 features:
   - "AI-powered career counselor with personalized entrepreneurship potential scoring"

--- a/data/partners.yaml
+++ b/data/partners.yaml
@@ -1,11 +1,11 @@
 - name: "priME Academy"
-  logo: "images/partners/prime-academy.png"
+  logo: "images/services/prime_logo.png"
   description: "EU-funded education projects and AI platform development"
 
 - name: "SUMO Technologies"
-  logo: "images/partners/sumo-technologies.png"
+  logo: "images/services/sumo_technologies_logo.png"
   description: "International project coordination and consortium management"
 
 - name: "Green Edu Seeds"
-  logo: "images/partners/green-edu-seeds.png"
+  logo: "images/services/GESeeds_logo.webp"
   description: "Erasmus+ CBHE project for sustainable education in Southeast Asia"

--- a/themes/synapsyx/layouts/_partials/sections/partners.html
+++ b/themes/synapsyx/layouts/_partials/sections/partners.html
@@ -138,7 +138,8 @@
                           {{ range .Site.Data.partners }}
                           <div class="partner-item">
                             <div class="partner-logo">
-                              <img src="{{ .logo | relURL }}" alt="{{ .name }}">
+                              {{ $logo := resources.Get .logo | fingerprint }}
+                              <img src="{{ $logo.RelPermalink }}" alt="{{ .name }}">
                             </div>
                             <div class="partner-overlay">
                               <p class="partner-description">{{ .description }}</p>

--- a/themes/synapsyx/layouts/home.html
+++ b/themes/synapsyx/layouts/home.html
@@ -2,8 +2,8 @@
   {{ partial "disqus.html" . }}
   {{ partial "sections/hero-section.html" (site.GetPage "sections/hero-section") }}
   {{ partial "sections/about-us.html" (site.GetPage "sections/about-us") }}
-  {{ partial "sections/epath-showcase.html" (site.GetPage "sections/epath-showcase") }}
   {{ partial "sections/services.html" (site.GetPage "sections/services") }}
+  {{ partial "sections/epath-showcase.html" (site.GetPage "sections/epath-showcase") }}
   {{ partial "sections/team.html" (site.GetPage "sections/team") }}
   {{ partial "sections/partners.html" . }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Move ePATH showcase section below Products section (instead of above)
- Revert ePATH product card image to original template illustration
- Wire up partner logos using actual uploaded files (prime_logo.png, sumo_technologies_logo.png, GESeeds_logo.webp)
- Fix partners template to use Hugo's resources.Get for assets/ directory

https://claude.ai/code/session_01GsyBEYxZ6G2a94tgQevMts