### PR TITLE
Website refresh: content, theme & copy + Safari pinwheel fix

### DIFF
--- a/content/sections/_index.md
+++ b/content/sections/_index.md
@@ -1,0 +1,6 @@
+---
+title: Sections
+build:
+  render: never
+  list: never
+---

--- a/content/sections/services/_index.md
+++ b/content/sections/services/_index.md
@@ -1,4 +1,7 @@
 ---
 title: "Our Products"
+build:
+  render: never
+  list: never
 ---
-Our products are in the hands of real users. ePATH is used by students at partner universities across Southeast Asia, and G/S-Flow powers automated project development and proposal work inside ongoing cross-border initiatives. Each one targets a specific problem for a specific audience.
+synapsyx develops custom AI systems and reusable workflows across client and funded projects. ePATH — our AI-supported career-orientation tool — is live with students in an Erasmus+ education context. Selected components from our project work are progressively developed into reusable products.

--- a/content/sections/services/ai-software-applications.md
+++ b/content/sections/services/ai-software-applications.md
@@ -1,6 +1,6 @@
 ---
 title: "ePATH"
-subtitle: "AI Career Guidance Platform"
+subtitle: "AI-supported career orientation & entrepreneurship reflection"
 image: "images/services/ePATH_home.png"
 alt: "ePATH: AI Career Guidance Platform"
 weight: 1
@@ -16,4 +16,4 @@ features:
   - "Built under Erasmus+ CBHE as part of the EU-funded Green Edu Seeds project"
 ---
 
-ePATH helps university students find a direction without forcing them through rigid questionnaires or leaving them to a generic chatbot. Modular, skippable questions gather the basics; a specialized AI counselor then lets students elaborate in their own words, explore career paths, and surface where their entrepreneurial strengths lie. Built with [priME Academy](https://www.primeacademy.eu) for the [Green Edu Seeds](https://green-edu-seeds.com) project, ePATH is embedded into MoodleCloud via LTI 1.3 and used by students at partner universities across Southeast Asia.
+ePATH helps university students find a direction without forcing them through rigid questionnaires or leaving them to a generic chatbot. Modular, skippable questions gather the basics; a specialized AI counselor then lets students elaborate in their own words, explore career paths, and reflect on entrepreneurial direction. Built with [priME Academy](https://www.primeacademy.eu) for the [Green Edu Seeds](https://green-edu-seeds.com) Erasmus+ project, ePATH is embedded into MoodleCloud via LTI 1.3 and used by students at partner universities in Vietnam and Thailand. ePATH supports reflection and orientation; it does not make admissions, employment, or other high-stakes decisions.

--- a/content/sections/team/_index.md
+++ b/content/sections/team/_index.md
@@ -1,6 +1,9 @@
 ---
 title: Our Team
 subTitle: Builders, Operators, & AI Specialists
+build:
+  render: never
+  list: never
 ---
 
 The strength of synapsyx lies in our dedicated team. We are a close-knit group brought together by a shared conviction that AI is the most important technology of our era. Our backgrounds are intentionally diverse and interdisciplinary, spanning computer science, engineering, economics, and law. This mix of perspectives allows us to approach problems creatively and build holistic solutions. Every team member brings international experience and a commitment to continuous learning, ensuring we stay at the frontier of AI development.

--- a/content/sections/team/george.md
+++ b/content/sections/team/george.md
@@ -1,7 +1,7 @@
 ---
 name: "Georg Thurnwalder, LL.B."
 image: "/images/team/george_nobg.png"
-position: "Managing Director · AI strategy & project development"
+position: "Co-founder & Managing Director · AI strategy"
 bioShort: "International business law background with three years of independent work in AI and international startup experience. Co-founder of an Austrian NGO."
 bioSummary: "International business law background with three years of independent work in AI and international startup experience. Co-founder of an Austrian NGO, bringing hands-on experience in building organizations from the ground up. He identifies strategic openings, tracks shifts in AI, and coordinates multi‑stakeholder execution that converts potential into real impact."
 linkedin: "https://www.linkedin.com/in/georg-t-719562213/"

--- a/content/sections/team/mathias.md
+++ b/content/sections/team/mathias.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 name: "Mathias Baumgartinger, BSc."
 image: "/images/team/mathias_nobg_new.png"
 position: "AI systems developer · product design"

--- a/content/sections/team/petar.md
+++ b/content/sections/team/petar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 name: "Petar Djordjevic-Ilic, BEng."
 image: "/images/team/petar_nobg_newnew.png"
 position: "Operations & delivery"

--- a/content/sections/team/strudl.md
+++ b/content/sections/team/strudl.md
@@ -1,7 +1,7 @@
 ---
 name: "Michael Strobl, BSc."
 image: "/images/team/michael_nobg.png"
-position: "Managing Director · AI systems & strategy"
+position: "Co-founder & Managing Director · AI systems"
 bioShort: "Drives digital-transformation and AI projects, combining a degree in Economics, Big 4 forensic-tech, and international startup experience."
 bioSummary: "Michael drives digital-transformation and AI projects. Drawing on a degree in Economics and Big 4 forensic-tech as well as international startup experience, Michael combines analytical rigour with hands-on product development."
 linkedin: "https://www.linkedin.com/in/michael-strobl-429a57211"

--- a/data/deployments.yaml
+++ b/data/deployments.yaml
@@ -8,16 +8,6 @@ hq:
   lng: 16.3738
   role: Headquarters
   description: synapsyx GmbH — applied AI R&D, systems development, project delivery, and company operations.
-  # Satellites travel with HQ on the globe + list — same magenta pin
-  # style as primary HQ, merged into the single "HQ" entry below.
-  satellites:
-    - city: Sydney
-      region: Australia
-      country: AU
-      lat: -33.8688
-      lng: 151.2093
-      role: Operations presence
-      description: Petar Djordjevic-Ilic — operations and delivery support, currently based in Australia.
 
 deployments:
   - region: Vietnam

--- a/data/partners.yaml
+++ b/data/partners.yaml
@@ -6,7 +6,7 @@
 - name: "SUMO Technologies"
   url: "https://www.sumo-technologies.com"
   logo: "images/services/sumo_technologies_logo.png"
-  description: "Project coordination, consortium experience, and innovation-project collaboration."
+  description: "Collaboration combining our technology and implementation expertise with education, consortium, funding, and transfer experience."
 
 - name: "Green Edu Seeds"
   url: "https://green-edu-seeds.com"

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,7 @@ theme = 'synapsyx'
   favicon = 'favicon.ico'
   brandword = "synapsyx"
   brandhtml = "synapsy<span class=\"brand-highlight\">x</span>"
-  description = "Applied AI R&D and implementation company for custom AI systems, agents, platforms, and workflow automation."
+  description = "Vienna-based AI company for custom AI systems, AI strategy and implementation, and AI-literacy education across Austria and the DACH region."
   canonifyURLs = true
   [params.contact]
     email = "contact@synapsyx.com"

--- a/themes/synapsyx/assets/css/v2.css
+++ b/themes/synapsyx/assets/css/v2.css
@@ -406,12 +406,18 @@ a:focus:not(:focus-visible){outline:none;}
 .about-mark.in .pw-5{transition-delay:0.54s;}
 .about-mark.in .pw-6{transition-delay:0.62s;}
 /* Ambient rotation of the inner pinwheel only (the hex outline stays put).
-   Pivot is set in SVG user-space coordinates: the hex centroid is at
-   (134.484, 447.55) in the viewBox. The animation only attaches once
+   We spin around the pinwheel's own bounding-box center via
+   transform-box:fill-box + transform-origin:center. This previously used
+   transform-box:view-box with an absolute-px pivot (the hex centroid at
+   134.484,447.55), but Safari resolves that origin in the wrong coordinate
+   space under page zoom, so the pinwheel drifts off-center and clips away
+   at most zoom levels. fill-box centers on the group's geometry — its bbox
+   center is (≈134.54, 447.55), sub-pixel from the hex centroid — and is
+   zoom-stable across browsers. The animation only attaches once
    .about-mark gets .in (added by the IntersectionObserver), and the
    1.6s delay holds until the entry draw — the last pw stroke finishes
    at 0.62s + 0.95s ≈ 1.57s — completes before rotation starts. */
-.about-mark .pw-spin{transform-box:view-box;transform-origin:134.484px 447.55px;}
+.about-mark .pw-spin{transform-box:fill-box;transform-origin:center;}
 .about-mark.in .pw-spin{animation:synx-pw-spin 100s linear 1.6s infinite;}
 @keyframes synx-pw-spin{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
 html[data-theme="light"] .about-mark{color:rgba(var(--magenta-rgb),0.13);}
@@ -527,7 +533,7 @@ html[data-theme="light"] .about-mark{color:rgba(var(--magenta-rgb),0.13);}
 =================================================== */
 .team{padding:120px 0;border-top:1px solid var(--line);position:relative;}
 .team::before{content:"";position:absolute;inset:0;background:repeating-linear-gradient(45deg, rgba(255,255,255,0.018) 0 1px, transparent 1px 22px);pointer-events:none;mask-image:linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 30%, rgba(0,0,0,0.5) 70%, rgba(0,0,0,0) 100%);-webkit-mask-image:linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 30%, rgba(0,0,0,0.5) 70%, rgba(0,0,0,0) 100%);}
-.team-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:12px;overflow:hidden;}
+.team-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:12px;overflow:hidden;}
 .member{background:var(--bg-2);padding:28px 24px 26px;display:flex;flex-direction:column;position:relative;min-height:340px;transition:background .3s ease, transform .3s ease;cursor:default;}
 .member:hover{background:var(--hover-bg);transform:translateY(-3px);}
 .member:hover .portrait{border-color:rgba(var(--magenta-rgb),0.45);color:var(--fg);}
@@ -640,7 +646,7 @@ html[data-theme="light"] .credibility .sep{background:rgba(15,15,16,0.22);}
    02 · CAPABILITIES — 2×2 card grid
 =================================================== */
 .capabilities{padding:120px 0;border-top:1px solid var(--line);}
-.cap-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:12px;overflow:hidden;}
+.cap-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:12px;overflow:hidden;}
 .cap{background:var(--bg-2);padding:36px 32px;display:flex;flex-direction:column;transition:background .25s ease;}
 .cap:hover{background:var(--hover-bg);}
 .cap .num{font-family:var(--mono);font-size:11px;letter-spacing:0.14em;color:var(--magenta);margin:0 0 14px;text-transform:uppercase;}

--- a/themes/synapsyx/layouts/_partials/v2/footer.html
+++ b/themes/synapsyx/layouts/_partials/v2/footer.html
@@ -19,7 +19,7 @@
     <div class="footer-grid reveal">
       <div class="footer-brand">
         <a href="{{ $logoHref }}" class="logo" aria-label="synapsyx home"><span aria-hidden="true">{{ $logoUse | safeHTML }}</span></a>
-        <p>Applied AI R&amp;D and implementation company for custom AI systems, agents, platforms, and workflow automation.</p>
+        <p>Vienna-based AI company for custom AI systems, AI strategy and implementation, and AI-literacy education.</p>
         <div class="addr">
           {{ range (split $contactAddress ", ") }}<span>{{ . }}</span>{{ end }}
           <span>Austria</span>
@@ -30,8 +30,8 @@
         <h3>Sections</h3>
         <ul>
           <li><a href="/#capabilities">Capabilities</a></li>
-          <li><a href="/#proof">Proof</a></li>
-          <li><a href="/#team">Team</a></li>
+          <li><a href="/#proof">Our work</a></li>
+          <li><a href="/#team">Founders</a></li>
           <li><a href="/#partners">Partners</a></li>
           <li><a href="mailto:{{ $contactEmail }}">Contact</a></li>
         </ul>

--- a/themes/synapsyx/layouts/_partials/v2/nav.html
+++ b/themes/synapsyx/layouts/_partials/v2/nav.html
@@ -16,8 +16,8 @@
   {{ if eq $kind "home" }}
   <div class="links">
     <a href="#capabilities" data-target="capabilities">Capabilities</a>
-    <a href="#proof" data-target="proof">Proof</a>
-    <a href="#team" data-target="team">Team</a>
+    <a href="#proof" data-target="proof">Our work</a>
+    <a href="#team" data-target="team">Founders</a>
     <a href="#partners" data-target="partners">Partners</a>
   </div>
   {{ end }}
@@ -32,8 +32,8 @@
   </button>
   <div class="nav-menu" id="navMenu" aria-hidden="true" inert>
     <a href="#capabilities" data-target="capabilities">Capabilities</a>
-    <a href="#proof" data-target="proof">Proof</a>
-    <a href="#team" data-target="team">Team</a>
+    <a href="#proof" data-target="proof">Our work</a>
+    <a href="#team" data-target="team">Founders</a>
     <a href="#partners" data-target="partners">Partners</a>
     <a class="cta" href="{{ $discussHref }}">Discuss a project <span aria-hidden="true">→</span></a>
   </div>

--- a/themes/synapsyx/layouts/home.html
+++ b/themes/synapsyx/layouts/home.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>(function(){try{var s=localStorage.getItem('synx_v2_theme');if(s==='light'||s==='dark'){if(s==='light')document.documentElement.setAttribute('data-theme','light');}else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches){document.documentElement.setAttribute('data-theme','light');}if(sessionStorage.getItem('synx_v2_loaded_once')==='1')document.documentElement.setAttribute('data-loaded','');}catch(e){}})();</script>
-  {{ $title := "synapsyx · Applied AI systems for complex workflows" }}
-  {{ $desc := "synapsyx is an applied AI R&D and implementation company for custom AI systems, agents, platforms, internal tools, and workflow automation." }}
+  {{ $title := "synapsyx · Applied AI systems, strategy, and AI literacy" }}
+  {{ $desc := "synapsyx is a Vienna-based AI company building custom AI systems, with AI strategy, implementation, and AI-literacy education for organizations across Austria and the DACH region." }}
   {{ $url := "https://www.synapsyx.com/" }}
   {{ $ogImage := resources.Get "v2/og-preview.png" | fingerprint }}
   <title>{{ $title }}</title>
@@ -27,7 +27,7 @@
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="synapsyx — applied AI systems for complex workflows. Vienna. ePATH live MVP and internal AI workflows.">
+  <meta property="og:image:alt" content="synapsyx — applied AI systems, strategy, and AI literacy. Vienna and the DACH region.">
   {{ end }}
 
   <meta name="twitter:card" content="summary_large_image">
@@ -111,7 +111,7 @@
     "@id" (printf "%s#epath" $url)
     "name" "ePATH"
     "alternateName" "ePATH AI counseling tool"
-    "description" "AI counseling tool for entrepreneurship education — combines structured interaction, scoring logic, and an AI counselor experience. Live MVP integrated into MoodleCloud via LTI 1.3 in the Green-Edu-Seeds education-platform context."
+    "description" "AI-supported tool for career orientation and entrepreneurship reflection — combines structured self-assessment logic with an AI counselor experience. Live MVP integrated into MoodleCloud via LTI 1.3 in the Green-Edu-Seeds Erasmus+ education context. Supports reflection and orientation; does not make high-stakes decisions."
     "applicationCategory" "EducationalApplication"
     "operatingSystem" "Web"
     "creator" (dict "@id" $orgID)
@@ -167,7 +167,7 @@
   {{ end }}
   {{ $entities := slice $org $website $webpage $internalWorkflows $epathSchema }}
   {{ range $places }}{{ $entities = $entities | append . }}{{ end }}
-  {{ $teamSlugsLD := slice "mathias" "george" "strudl" "petar" }}
+  {{ $teamSlugsLD := slice "george" "strudl" }}
   {{ range $teamSlugsLD }}
     {{ $slug := . }}
     {{ $m := $.Site.GetPage (printf "/sections/team/%s" $slug) }}
@@ -216,33 +216,23 @@
   }}
 {{ end }}
 {{ $epath := .Site.GetPage "/sections/services/ai-software-applications" }}
-{{ $teamMathias := .Site.GetPage "/sections/team/mathias" }}
 {{ $teamGeorge := .Site.GetPage "/sections/team/george" }}
 {{ $teamMichael := .Site.GetPage "/sections/team/strudl" }}
-{{ $teamPetar := .Site.GetPage "/sections/team/petar" }}
 
 {{/* Bios (and titles) inlined here so the team copy at /sections/team/*
      stays untouched. Keys match the team markdown filename. */}}
 {{ $teamCopy := dict
   "george" (dict
     "title" "Georg Thurnwalder, LL.B."
-    "role"  "Managing Director · AI strategy & project development"
+    "role"  "Co-founder & Managing Director · AI strategy"
     "bio"   "International business law background with three years of independent work in AI and international startup experience. Co-founder of an Austrian NGO.")
   "strudl" (dict
     "title" "Michael Strobl, BSc."
-    "role"  "Managing Director · AI systems & strategy"
+    "role"  "Co-founder & Managing Director · AI systems"
     "bio"   "Drives digital-transformation and AI projects, combining a degree in Economics, Big 4 forensic-tech, and international startup experience.")
-  "mathias" (dict
-    "title" "Mathias Baumgartinger, BSc."
-    "role"  "AI systems developer · product design"
-    "bio"   "Computer scientist with 6+ years in software development, geospatial analytics, and machine learning. MSc candidate in Computer Science at University of Vienna.")
-  "petar" (dict
-    "title" "Petar Djordjevic-Ilic, BEng."
-    "role"  "Operations & delivery"
-    "bio"   "Chemical engineer with a track record of delivering US $40 million-plus engineering programs and international startup experience across Australia and Korea.")
 }}
-{{ $teamSlugOrder := slice "george" "strudl" "mathias" "petar" }}
-{{ $teamPagesBySlug := dict "george" $teamGeorge "strudl" $teamMichael "mathias" $teamMathias "petar" $teamPetar }}
+{{ $teamSlugOrder := slice "george" "strudl" }}
+{{ $teamPagesBySlug := dict "george" $teamGeorge "strudl" $teamMichael }}
 
 {{ $contactEmail := .Site.Params.contact.email | default "contact@synapsyx.com" }}
 {{ $contactAddress := .Site.Params.contact.address | default "Steigenteschgasse 13, 1220 Wien" }}
@@ -273,7 +263,7 @@
         <span>Vienna</span>
       </p>
       <h1 id="hero-heading">Applied AI systems for <span class="accent">complex&nbsp;workflows</span>.</h1>
-      <p class="sub">We design, build, and implement AI pipelines, agents, internal tools, and platforms — from early prototypes to operational systems and funded innovation projects.</p>
+      <p class="sub">We build custom AI systems, guide AI strategy and implementation, and teach AI literacy — from prototypes to operational systems and funded innovation projects.</p>
       <div class="ctas">
         <a class="btn primary" href="{{ $discussHref }}">Discuss a project <span class="arr" aria-hidden="true">→</span></a>
         <a class="btn ghost" href="#capabilities">View capabilities <span class="arr" aria-hidden="true">→</span></a>
@@ -282,14 +272,6 @@
         <div class="item">
           <span class="k">ePATH</span>
           <span class="v"><span class="dot"></span>Live MVP · deployed pilot</span>
-        </div>
-        <div class="item">
-          <span class="k">Internal AI workflows</span>
-          <span class="v">Research · documentation · quality review</span>
-        </div>
-        <div class="item">
-          <span class="k">Location</span>
-          <span class="v">Vienna, AT · Sydney, AU</span>
         </div>
         <div class="item">
           <span class="k">Focus</span>
@@ -304,17 +286,13 @@
     <div class="wrap">
       <span class="item">Austrian company</span>
       <span class="sep" aria-hidden="true"></span>
-      <span class="item">Applied AI R&amp;D</span>
-      <span class="sep" aria-hidden="true"></span>
       <span class="item">Custom AI systems</span>
       <span class="sep" aria-hidden="true"></span>
-      <span class="item">AI agents</span>
+      <span class="item">AI agents &amp; automation</span>
       <span class="sep" aria-hidden="true"></span>
-      <span class="item">Workflow automation</span>
+      <span class="item">Strategy &amp; implementation</span>
       <span class="sep" aria-hidden="true"></span>
-      <span class="item">Internal tools</span>
-      <span class="sep" aria-hidden="true"></span>
-      <span class="item">Strategy and implementation</span>
+      <span class="item">AI literacy &amp; education</span>
     </div>
   </section>
 
@@ -343,7 +321,7 @@
         <div class="left">
           <p class="num"><span class="bar"></span> 01 · About</p>
           <h2 id="about-heading">A young Austrian AI company built for implementation.</h2>
-          <p class="lede">synapsyx GmbH is a Vienna-based applied AI R&amp;D and implementation company. We build custom AI systems for workflows where generic tools are not enough.</p>
+          <p class="lede">synapsyx GmbH is a Vienna-based AI company working across development, strategy, and education. We work mainly with education, research, social-sector, and publicly funded organizations across Austria and the DACH region.</p>
         </div>
         <div class="right">
           <span class="count">2025</span>
@@ -354,7 +332,7 @@
       <div class="about-grid">
         <div class="about-body">
           <p>We build custom AI systems for workflows where generic tools fall short: <span class="b">internal knowledge work, document-heavy processes, education platforms, research and innovation projects, and operational decision support</span>.</p>
-          <p>Our work combines hands-on AI experimentation, software development, context engineering, structured evaluation, and project delivery. We do not only advise on AI — we build systems, test them in real workflows, and use our own internal tools to improve how we work.</p>
+          <p>Our work combines hands-on AI experimentation, software development, context engineering, structured evaluation, and project delivery. We combine strategy, implementation, and education — from identifying suitable use cases to building systems, evaluating them, supporting adoption, and gradually turning proven components into reusable products.</p>
         </div>
 
         <div class="about-stats reveal reveal-delay-1">
@@ -419,62 +397,49 @@
       <div class="section-head reveal">
         <div class="left">
           <p class="num"><span class="bar"></span> 02 · Capabilities</p>
-          <h2 id="capabilities-heading">What we build.</h2>
-          <p class="lede">We work where AI has to fit into real processes, sensitive information flows, and practical implementation constraints.</p>
+          <h2 id="capabilities-heading">What we do.</h2>
+          <p class="lede">We work where AI has to fit into real processes, sensitive information flows, and practical implementation constraints — across development, strategy, and education.</p>
         </div>
         <div class="right">
-          <span class="count">04</span>
-          Practice areas
+          <span class="count">03</span>
+          Pillars
         </div>
       </div>
 
       <div class="cap-grid reveal reveal-delay-1">
         <div class="cap">
-          <p class="num">01 / Build</p>
-          <h3>AI systems development</h3>
-          <p>Custom AI tools, platforms, pipelines, dashboards, internal applications, integrations, and workflow interfaces for organizations that need more than an off-the-shelf chatbot.</p>
+          <p class="num">01 / Develop</p>
+          <h3>AI solution development</h3>
+          <p>Custom AI tools, platforms, pipelines, internal applications, agents, and workflow automation for organizations that need more than an off-the-shelf chatbot.</p>
           <ul>
-            <li>Custom AI applications</li>
+            <li>Custom AI applications and platforms</li>
+            <li>AI agents and workflow automation</li>
             <li>Internal tools and dashboards</li>
-            <li>Workflow interfaces</li>
             <li>API and platform integrations</li>
             <li>Prototype-to-implementation development</li>
           </ul>
         </div>
         <div class="cap">
-          <p class="num">02 / Automate</p>
-          <h3>AI agents and workflow automation</h3>
-          <p>Controlled agent workflows for research, drafting, classification, document processing, information management, and expert review.</p>
+          <p class="num">02 / Implement</p>
+          <h3>AI strategy and implementation</h3>
+          <p>We help teams identify where AI is useful and feasible, then deliver it — including R&amp;D and funded innovation projects, with evaluation built in.</p>
           <ul>
-            <li>Research and document workflows</li>
-            <li>Classification and structured outputs</li>
-            <li>Drafting and comparison pipelines</li>
-            <li>Human-in-the-loop review</li>
-            <li>Automation of repetitive knowledge work</li>
-          </ul>
-        </div>
-        <div class="cap">
-          <p class="num">03 / Strategy</p>
-          <h3>AI strategy and opportunity discovery</h3>
-          <p>We help teams identify where AI is useful, feasible, and worth implementing — then translate that into concrete prototypes, systems, and roadmaps.</p>
-          <ul>
-            <li>AI readiness and workflow analysis</li>
-            <li>Use-case selection</li>
-            <li>Feasibility assessment</li>
-            <li>Risk and constraint mapping</li>
+            <li>AI readiness and use-case selection</li>
+            <li>Feasibility and risk mapping</li>
             <li>Implementation roadmaps</li>
+            <li>R&amp;D and technical work packages</li>
+            <li>Evaluation, quality control, and funded-project support</li>
           </ul>
         </div>
         <div class="cap">
-          <p class="num">04 / R&amp;D</p>
-          <h3>R&amp;D and innovation projects</h3>
-          <p>We support AI innovation projects from concept to implementation: technical work packages, prototypes, evaluation logic, documentation, implementation planning, and partner coordination.</p>
+          <p class="num">03 / Educate</p>
+          <h3>AI literacy and education</h3>
+          <p>We build AI capability inside teams and institutions through hands-on, practical formats grounded in real implementation experience.</p>
           <ul>
-            <li>Prototype development</li>
-            <li>Technical work packages</li>
-            <li>Evaluation and quality control</li>
-            <li>Documentation and implementation planning</li>
-            <li>Funded innovation project support</li>
+            <li>AI-literacy workshops and guest teaching</li>
+            <li>Prompt- and context-engineering training</li>
+            <li>AI-supported project-management formats</li>
+            <li>Adoption and enablement support</li>
           </ul>
         </div>
       </div>
@@ -486,9 +451,9 @@
     <div class="wrap">
       <div class="section-head reveal">
         <div class="left">
-          <p class="num"><span class="bar"></span> 03 · Proof</p>
-          <h2 id="proof-heading">Selected systems, workflows, and capability proof.</h2>
-          <p class="lede">Many AI implementation projects involve sensitive workflows, data, or strategic plans. We therefore show selected public examples, anonymized project snapshots, and internal capability proof. Additional details and walkthroughs are available where appropriate.</p>
+          <p class="num"><span class="bar"></span> 03 · Our work</p>
+          <h2 id="proof-heading">Selected systems and work.</h2>
+          <p class="lede">Many AI projects involve sensitive workflows, data, or strategic plans, so we show selected public examples, anonymized project snapshots, and internal systems we use ourselves. More detail is available where appropriate.</p>
         </div>
         <div class="right">
           <span class="count">05</span>
@@ -539,8 +504,8 @@
               <span class="status mg">Live MVP · deployed pilot</span>
             </div>
             <h3>ePATH</h3>
-            <p class="tagline">AI counseling tool for entrepreneurship education</p>
-            <p class="lede">ePATH is an AI-guided student support tool developed for entrepreneurship education. It combines structured interaction, scoring logic, and an AI counselor experience to help students reflect on career direction and entrepreneurial potential.</p>
+            <p class="tagline">AI-supported career orientation and entrepreneurship reflection</p>
+            <p class="lede">ePATH is an AI-supported tool for career orientation and entrepreneurship reflection. It combines structured self-assessment logic with an AI counselor experience to help students explore career direction. Deployed via LTI 1.3 in MoodleCloud within an Erasmus+ education context, ePATH supports reflection and orientation — it does not make admissions, employment, or other high-stakes decisions.</p>
             <ul class="features">
               <li><span class="tick"></span><span class="text"><span class="b">Hybrid design combining skippable modular questionnaires with open-ended AI counselor dialogue</span></span></li>
               <li><span class="tick"></span><span class="text"><span class="b">Questionnaire and AI recommendations benchmarked against O*NET occupational data during development</span></span></li>
@@ -617,7 +582,7 @@
         <div class="left">
           <p class="num"><span class="bar"></span> 04 · Approach</p>
           <h2 id="approach-heading">Fast experimentation, disciplined implementation.</h2>
-          <p class="lede">AI projects move quickly, but serious implementation still needs structure. We work in short cycles that make assumptions visible, test technical feasibility early, and keep review points explicit.</p>
+          <p class="lede">AI projects move quickly, but serious implementation still needs structure. We work in short cycles that make assumptions visible, test technical feasibility early, and keep review points explicit. We keep people in control of meaningful decisions, design for privacy and accessibility, and avoid training proprietary models.</p>
         </div>
         <div class="right">
           <span class="count">05</span>
@@ -660,13 +625,13 @@
     <div class="wrap">
       <div class="section-head reveal">
         <div class="left">
-          <p class="num"><span class="bar"></span> 05 · Team</p>
-          <h2 id="team-heading">Builders, operators, and applied AI specialists.</h2>
-          <p class="lede">We are a small interdisciplinary team combining technical implementation, project development, AI experimentation, operations, economics, law, engineering, and international delivery experience. Our size allows us to move quickly, while our process keeps projects structured and reviewable.</p>
+          <p class="num"><span class="bar"></span> 05 · Founders</p>
+          <h2 id="team-heading">Founder-led and implementation-focused.</h2>
+          <p class="lede">synapsyx is led by its two founders, who combine AI systems development, product work, and AI strategy with backgrounds in economics, law, and organization-building. We operate as a small core team and bring in specialist collaborators and partners on individual projects.</p>
         </div>
         <div class="right">
-          <span class="count">04</span>
-          Vienna · Sydney
+          <span class="count">02</span>
+          Vienna
         </div>
       </div>
 


### PR DESCRIPTION
Replaces the current live site with the refreshed version. The current live version is preserved as the tag `live-original-2026-06-21` (commit `0133abb`) for easy rollback.

## What's included

**Content & copy**
- Reworded site meta description (now "Vienna-based AI company…")
- Updated team, services, and section copy; partner, footer, and nav text
- Removed the Sydney satellite entry from `data/deployments.yaml`
- Home page layout restructure

**Bug fix — Safari pinwheel rotation**
- The rotating inner pinwheel in the About section drifted off-center / vanished in Safari at most zoom levels. Root cause: WebKit mis-resolves `transform-box: view-box` combined with an absolute-px `transform-origin`. Switched to `transform-box: fill-box` + `transform-origin: center`, which pivots on the group's own bounding box and is zoom-stable across browsers. Chrome/Firefox rendering is unchanged.

## Deploy
Merging this PR pushes to `main` and triggers the **Deploy Hugo site to Pages** workflow, updating https://www.synapsyx.com (~1 min).

## Revert (both non-destructive)
1. **One-click:** use GitHub's **Revert** button on this PR after merging — it opens a revert PR; merge that and the original redeploys.
2. **Roll back to the tag:** the original is permanently tagged `live-original-2026-06-21` (commit `0133abb`).

## Verified
- Production build (`hugo --gc --minify`) succeeds with all changes present.
- Pinwheel fix confirmed by geometry (bounding-box center ≈ intended hex centroid, sub-pixel). Final Safari visual check across zoom levels is best done on the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
