### PR TITLE
Shorten hero eyebrow to "Applied AI"

### DIFF
--- a/themes/synapsyx/layouts/home.html
+++ b/themes/synapsyx/layouts/home.html
@@ -258,7 +258,7 @@
     <div class="hero-inner">
       <p class="eyebrow">
         <span class="bar"></span>
-        <span>Applied AI R&amp;D</span>
+        <span>Applied AI</span>
         <span class="dot-sep"></span>
         <span>Vienna</span>
       </p>


### PR DESCRIPTION
One-line copy change: the hero eyebrow now reads "Applied AI · Vienna" instead of "Applied AI R&D · Vienna".

(This commit was originally pushed to the `epath-live-production-copy` branch just after PR #19 merged, so it never made it into main — re-applied here on a fresh branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)